### PR TITLE
#170069835 Add UUID to user table

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,9 +1,8 @@
 module Types
   class UserType < Types::BaseObject
-    field :id, ID, null: false
+    field :uuid, String, null: false
     field :email, String, null: false
     field :screen_name, String, null: false
     field :name, String, null: true
-    field :password_digest, String, null: true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,9 @@ class User < ApplicationRecord
   validates_presence_of :email, :screen_name, :password_digest
   validates :email, uniqueness: true
   validates :screen_name, uniqueness: true
+  before_save :set_uuid
+
+  def set_uuid
+    self.uuid = SecureRandom.uuid
+  end
 end

--- a/db/migrate/20191104114118_create_users.rb
+++ b/db/migrate/20191104114118_create_users.rb
@@ -1,10 +1,13 @@
 class CreateUsers < ActiveRecord::Migration[5.2]
   def change
+    enable_extension 'pgcrypto'
+
     create_table :users do |t|
-      t.string :screen_name, index: {unique: true}
+      t.string :screen_name, null: false, index: { unique: true }
       t.string :name
-      t.string :email, index: {unique: true}
-      t.string :password_digest
+      t.string :email, null: false, index: { unique: true }
+      t.string :password_digest, null: false
+      t.uuid :uuid, null: false, index: { unique: true }
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,17 +13,20 @@
 ActiveRecord::Schema.define(version: 2019_11_04_114118) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string "screen_name"
+    t.string "screen_name", null: false
     t.string "name"
-    t.string "email"
-    t.string "password_digest"
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.uuid "uuid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["screen_name"], name: "index_users_on_screen_name", unique: true
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
 end

--- a/spec/graphql/mutations/users/create_user_spec.rb
+++ b/spec/graphql/mutations/users/create_user_spec.rb
@@ -19,7 +19,7 @@ module Mutations
 
           expect(data).to include(
                             'user' => {
-                              'id' => be_present,
+                              'uuid' => be_present,
                               'email' => 'a@b.com',
                               'screenName' => 'tester_a',
                             },
@@ -56,7 +56,7 @@ module Mutations
               name: "#{user[:name]}"
             }) {
               user {
-                id
+                uuid
                 email
                 screenName
               }

--- a/spec/graphql/mutations/users/user_login_spec.rb
+++ b/spec/graphql/mutations/users/user_login_spec.rb
@@ -22,7 +22,7 @@ module Mutations
 
           expect(data).to include(
                             'user' => {
-                              'id' => be_present,
+                              'uuid' => be_present,
                               'email' => 'test@test.com',
                               'screenName' => 'tester_p'
                             },
@@ -71,7 +71,7 @@ module Mutations
               password: "#{user[:password]}"
             }) {
               user {
-                id
+                uuid
                 email
                 screenName
               }


### PR DESCRIPTION
#### What does this PR do
- Add `UUID` to user table

#### Description of Task to be completed
- Enable postgres `pgcrypto`
- Add `uuid` column to `User` table
- Modify GraphQL `User Type` to reflect `uuid` field
- Modify GRAPQL `create_user` and `user_login` mutation specs to reflect `uuid` field

#### How should this be manually tested
- Observe returned data on `user creation` or `login` to see `uuid` instead of `id` in returned data 

#### What are the relevant pivotal tracker stories?
[#170069835](https://www.pivotaltracker.com/story/show/170069835)

#### Screenshots
- NIL

