### PR TITLE
#170051769 Add create_post mutation

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -3,10 +3,8 @@ class GraphqlController < ApplicationController
     variables = ensure_hash(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
-    token = request.headers['HTTP_AUTHORIZATION'] ? request.headers['HTTP_AUTHORIZATION'].gsub(/[\n\t\b\"\']/, "") : nil
-    token = token.present? ? token : nil
+    token = parse_token(request.headers['HTTP_AUTHORIZATION'])
     context = {
-      # Query context goes here, for example:
       current_user: {
         token: token
       }
@@ -43,5 +41,11 @@ class GraphqlController < ApplicationController
     logger.error e.backtrace.join("\n")
 
     render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
+  end
+
+  def parse_token(source)
+    token = nil
+    token = source.gsub(/[\n\t\b\"\']/, "") if source.present?
+    token.blank? ? nil : token
   end
 end

--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -1,0 +1,7 @@
+module Mutations
+  module Posts
+    class CreatePost < Mutations::BaseMutation
+
+    end
+  end
+end

--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -14,7 +14,7 @@ module Mutations
           search_means = TopicsHelper::Topics.default_topic_search_means
           topic = TopicsHelper::Topics.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
           topic_owner = topic.user
-          ExceptionHandlerHelper::GQLCustomError.new(MessagesHelper::Auth.user_unauthorized) unless auth.isAuthorized?(topic_owner[:uuid])
+          return ExceptionHandlerHelper::GQLCustomError.new(MessagesHelper::Auth.user_unauthorized) unless auth.isAuthorized?(topic_owner[:uuid])
           title = "Untitled" if title.blank?
           PostHelper::Posts.create(title, content, topic[:id])
         else

--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -1,7 +1,26 @@
 module Mutations
   module Posts
     class CreatePost < Mutations::BaseMutation
+      argument :title, String, required: false
+      argument :content, String, required: false
+      argument :topic_uuid, String, required: true
 
+      field :post, Types::PostType, null: true
+
+      def resolve(title: "Untitled", content: "", topic_uuid:)
+        auth = AuthHelper::Auth.new(context[:current_user][:token])
+        token_data = auth.verify_token
+        if token_data[:verified?]
+          search_means = TopicsHelper::Topics.default_topic_search_means
+          topic = TopicsHelper::Topics.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
+          topic_owner = topic.user
+          ExceptionHandlerHelper::GQLCustomError.new(MessagesHelper::Auth.user_unauthorized) unless auth.isAuthorized?(topic_owner[:uuid])
+          title = "Untitled" if title.blank?
+          PostHelper::Posts.create(title, content, topic[:id])
+        else
+          ExceptionHandlerHelper::GQLCustomError.new(MessagesHelper::Auth.token_verification_error)
+        end
+      end
     end
   end
 end

--- a/app/graphql/mutations/topics/create_topic.rb
+++ b/app/graphql/mutations/topics/create_topic.rb
@@ -12,6 +12,7 @@ module Mutations
         if token_data[:verified?]
           search_means = UsersHelper::Users.default_user_search_means
           current_user_id = UsersHelper::Users.fetch_by("#{search_means}": token_data[:verified_user][:uuid])[:id]
+          title = "Untitled" if title.blank?
           TopicsHelper::Topics.create(title, is_public, current_user_id)
         else
           ExceptionHandlerHelper::GQLCustomError.new(MessagesHelper::Auth.token_verification_error)

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -3,5 +3,6 @@ module Types
     field :create_user, mutation: Mutations::Users::CreateUser
     field :user_login, mutation: Mutations::Users::UserLogin
     field :create_topic, mutation: Mutations::Topics::CreateTopic
+    field :create_post, mutation: Mutations::Posts::CreatePost
   end
 end

--- a/app/graphql/types/post_type.rb
+++ b/app/graphql/types/post_type.rb
@@ -1,0 +1,7 @@
+module Types
+  class PostType < Types::BaseObject
+    field :uuid, String, null: false
+    field :title, String, null: false
+    field :content, String, null: false
+  end
+end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -39,7 +39,5 @@ module AuthHelper
     def isAuthorized?(resource_owner_uuid)
       resource_owner_uuid === @decoded[:uuid]
     end
-
   end
-
 end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -16,7 +16,10 @@ module MessagesHelper
       "Access Denied!. Expired token"
     end
     def self.token_verification_error
-      "Access Denied. Couldn't verify token validity"
+      "Access Denied!. Couldn't verify token validity"
+    end
+    def self.user_unauthorized
+      "User is unauthorized to perform this action"
     end
   end
 end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,0 +1,18 @@
+module PostHelper
+  class Posts
+    def self.create(title, content, topic_id)
+      post = Post.new(title: title, content: content, topic_id: topic_id)
+      if post.save
+       {
+         "post": {
+           "uuid": post[:uuid],
+           "title": post[:title],
+           "content": post[:content]
+         }
+       }
+      else
+        ExceptionHandlerHelper::GQLCustomError.new(post.errors.full_messages)
+      end
+    end
+  end
+end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -13,5 +13,13 @@ module TopicsHelper
         ExceptionHandlerHelper::GQLCustomError.new(topic.errors.full_messages)
       end
     end
+
+    def self.fetch_with_relationship_by(type, relationship)
+      Topic.includes(relationship).find_by(type)
+    end
+
+    def self.default_topic_search_means
+      "uuid"
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,10 @@
+class Post < ApplicationRecord
+  belongs_to :topic
+  before_save :set_uuid
+  validates :uuid, uniqueness: true
+
+  private
+  def set_uuid
+    self.uuid = SecureRandom.uuid
+  end
+end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,6 +1,6 @@
 class Topic < ApplicationRecord
   belongs_to :user
-  has_many :posts
+  has_many :posts, dependent: :destroy
   validates :uuid, uniqueness: true
   before_save :set_uuid
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,10 +1,10 @@
 class Topic < ApplicationRecord
   belongs_to :user
-
+  has_many :posts
   validates :uuid, uniqueness: true
-
   before_save :set_uuid
 
+  private
   def set_uuid
     self.uuid = SecureRandom.uuid
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :screen_name, uniqueness: true
   before_save :set_uuid
-  has_many :topics
+  has_many :topics, dependent: :destroy
   has_many :posts, through: :topics
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,11 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :screen_name, uniqueness: true
   before_save :set_uuid
+  has_many :topics
+  has_many :posts, through: :topics
 
+
+  private
   def set_uuid
     self.uuid = SecureRandom.uuid
   end

--- a/db/migrate/20191216145052_create_posts.rb
+++ b/db/migrate/20191216145052_create_posts.rb
@@ -1,0 +1,10 @@
+class CreatePosts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :posts do |t|
+      t.references :topic, foreign_key: true
+      t.uuid :uuid, null: false, index: { unique: true }
+      t.string :title, null: false, default: "Untitled"
+      t.text :content
+    end
+  end
+end

--- a/db/migrate/20191216145052_create_posts.rb
+++ b/db/migrate/20191216145052_create_posts.rb
@@ -4,7 +4,7 @@ class CreatePosts < ActiveRecord::Migration[5.2]
       t.references :topic, foreign_key: true
       t.uuid :uuid, null: false, index: { unique: true }
       t.string :title, null: false, default: "Untitled"
-      t.text :content
+      t.text :content, null: false, default: ""
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_112842) do
+ActiveRecord::Schema.define(version: 2019_12_16_145052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "topic_id"
+    t.uuid "uuid", null: false
+    t.string "title", default: "Untitled", null: false
+    t.text "content"
+    t.index ["topic_id"], name: "index_posts_on_topic_id"
+    t.index ["uuid"], name: "index_posts_on_uuid", unique: true
+  end
 
   create_table "topics", force: :cascade do |t|
     t.bigint "user_id"
@@ -40,5 +49,6 @@ ActiveRecord::Schema.define(version: 2019_12_06_112842) do
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
+  add_foreign_key "posts", "topics"
   add_foreign_key "topics", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2019_12_16_145052) do
     t.bigint "topic_id"
     t.uuid "uuid", null: false
     t.string "title", default: "Untitled", null: false
-    t.text "content"
+    t.text "content", default: "", null: false
     t.index ["topic_id"], name: "index_posts_on_topic_id"
     t.index ["uuid"], name: "index_posts_on_uuid", unique: true
   end

--- a/spec/graphql/mutations/posts/create_post_spec.rb
+++ b/spec/graphql/mutations/posts/create_post_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+module Mutations
+  module Posts
+    RSpec.describe CreatePost, type: :request  do
+      describe '.resolve' do
+        token = nil
+        topic_uuid = nil
+        before(:all) do
+          create(:user)
+          post '/graphql', params: { query: login_mutation(dummy_login_credentials) }
+          json = JSON.parse(response.body)
+          token = json['data']['userLogin']['token']
+        end
+
+        after(:all) do
+          User.destroy_all
+        end
+
+        before(:each) do
+          post '/graphql', params: { query: create_topic_mutation(dummy_topic_credentials('successful')) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          topic_uuid = json['data']['createTopic']['topic']['uuid']
+        end
+
+        after(:each) do
+          Topic.destroy_all
+        end
+
+        it 'should not successfully create a post' do
+          post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid)) }
+          json = JSON.parse(response.body)
+          error = json['errors'][0]
+          expect(error).to include( "message" => MessagesHelper::Auth.token_verification_error )
+        end
+
+        it 'should successfully create a post for a topic' do
+          post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid)) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          post = json['data']['createPost']['post']
+          expect(post).to include(
+                            "uuid" => be_present,
+                            "title" => dummy_post_credentials[:title],
+                            "content" => dummy_post_credentials[:content]
+                          )
+        end
+
+        it 'should successfully create post with the right title in every situation' do
+          post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid, "")) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          post = json['data']['createPost']['post']
+          expect(post).to include(
+                            "uuid" => be_present,
+                            "title" => "Untitled",
+                            "content" => dummy_post_credentials[:content]
+                          )
+        end
+
+        it 'should successfully create post with the right content in every situation' do
+          post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid, "", nil)) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          post = json['data']['createPost']['post']
+          expect(post).to include(
+                            "uuid" => be_present,
+                            "title" => "Untitled",
+                            "content" => ""
+                          )
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/mutations/topics/create_topic_spec.rb
+++ b/spec/graphql/mutations/topics/create_topic_spec.rb
@@ -6,7 +6,7 @@ module Mutations
         token = nil
         before(:all) do
           create(:user)
-          post '/graphql', params: { query: login_mutation(dummyLoginCredentials) }
+          post '/graphql', params: { query: login_mutation(dummy_login_credentials) }
           json = JSON.parse(response.body)
           token = json['data']['userLogin']['token']
         end
@@ -16,7 +16,7 @@ module Mutations
         end
 
         it 'should not successfully create a topic' do
-          post '/graphql', params: { query: create_topic_mutation(dummyTopicCredential) }
+          post '/graphql', params: { query: create_topic_mutation(dummy_topic_credentials) }
 
           json = JSON.parse(response.body)
           error = json['errors'][0]
@@ -24,7 +24,8 @@ module Mutations
         end
 
         it 'should successfully create a topic without one supplied credential' do
-          post '/graphql', params: { query: create_topic_mutation(dummyTopicCredential('successful')) },headers: { Authorization: token }
+          post '/graphql', params: { query: create_topic_mutation(dummy_topic_credentials('successful')) },
+               headers: { Authorization: token }
           json = JSON.parse(response.body)
           topic = json['data']['createTopic']['topic']
           expect(topic).to include(
@@ -34,7 +35,8 @@ module Mutations
         end
 
         it 'should successfully create a topic with all supplied credentials' do
-          post '/graphql', params: { query: create_topic_mutation(dummyTopicCredential('second test', true)) }, headers: { Authorization: token }
+          post '/graphql', params: { query: create_topic_mutation(dummy_topic_credentials('second test', true)) },
+               headers: { Authorization: token }
           json = JSON.parse(response.body)
           topic = json['data']['createTopic']['topic']
           expect(topic).to include(

--- a/spec/helpers/general_spec_helpers.rb
+++ b/spec/helpers/general_spec_helpers.rb
@@ -58,17 +58,44 @@ module Helpers
       GQL
     end
 
-    def dummyLoginCredentials(email='test@test.com', password= '1234567890')
+    def create_post_mutation(post)
+      <<~GQL
+        mutation {
+          createPost(input: {
+            title: "#{post[:title]}"
+            content: "#{post[:content]}"
+            topicUuid: "#{post[:topic_uuid]}"
+          })
+          {
+            post {
+              uuid
+              title
+              content
+            }
+          }
+        }
+      GQL
+    end
+
+    def dummy_login_credentials(email='test@test.com', password= '1234567890')
       {
         email: email,
         password: password
       }
     end
 
-    def dummyTopicCredential(title='xyz', is_public=true)
+    def dummy_topic_credentials(title='xyz', is_public=true)
       {
         title: title,
         is_public: is_public
+      }
+    end
+
+    def dummy_post_credentials(topic_uuid=nil, title='test post', content='my test content')
+      {
+       title: title,
+       content: content,
+       topic_uuid: topic_uuid
       }
     end
   end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  describe 'Post model' do
+    topic = nil
+    before(:all) do
+      create(:user)
+      user = User.first
+      topic_obj = dummy_topic_credentials
+      topic = Topic.create!(user: user, title: topic_obj[:title], is_public: topic_obj[:is_public])
+    end
+
+    after(:all) do
+      User.destroy_all
+    end
+
+    after(:each) do
+      Post.destroy_all
+    end
+
+    it 'should create Post with default values if no values are supplied' do
+      post = Post.create!(topic: topic)
+      expect(post[:title]).to eq('Untitled')
+      expect(post[:content]).to eq('')
+      expect(post[:uuid]).to be_present
+    end
+
+    it 'should create Post with supplied values' do
+      post_obj = dummy_post_credentials(nil)
+      post = Post.create!(topic:topic, title: post_obj[:title], content: post_obj[:content] )
+      expect(post[:title]).to eq(post_obj[:title])
+      expect(post[:content]).to eq(post_obj[:content])
+      expect(post[:uuid]).to be_present
+    end
+  end
+end

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Topic, type: :model do
       Topic.destroy_all
     end
 
-    it 'should create topic with default values if nothing is supplied' do
+    it 'should create topic with default values if no values are supplied' do
       topic = Topic.create!(user: user)
       expect(topic[:title]).to eq('Untitled')
       expect(topic[:is_public]).to eq(false)


### PR DESCRIPTION
#### What does this PR do
- This PR adds functionality to create a `Post`

#### Description of Task to be completed
- Add `createPost` mutation
- Secure `createPost` mutation for use by only authorised users
- Add appropriate database relationships to link `topic` to `post`
- Secure `topic` such that only topic owner can add `post` to given `topic`

#### How should this be manually tested
- Checkout into this branch and run bundle install and yarn install
- Issue a post request to `localhost:3000/graphiql`
- Supply `topic_id`, `title` and `content` to `createPost` mutation

#### What are the relevant pivotal tracker stories?
[#170051769](https://www.pivotaltracker.com/story/show/170051769)

#### Screenshots
- NIL
