### PR TITLE
#170309004 Add update_post mutation

### DIFF
--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -13,7 +13,7 @@ module Mutations
       field :post, Types::PostType, null: true
 
       def resolve(title: "Untitled", content: "", topic_uuid:)
-        auth = AuthHelper::Auth.new(context[:current_user][:token])
+        auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
         search_means = TOPIC_HELPER.default_topic_search_means

--- a/app/graphql/mutations/posts/update_post.rb
+++ b/app/graphql/mutations/posts/update_post.rb
@@ -1,0 +1,31 @@
+module Mutations
+  module Posts
+    class UpdatePost < Mutations::BaseMutation
+      AUTH_HELPER = AuthHelper::Auth
+      AUTH_MSG_HELPER = MessagesHelper::Auth
+      EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
+      POST_HELPER = PostHelper::Posts
+      USERS_HELPER = UsersHelper::Users
+
+      argument :content, String, required: false
+      argument :title, String, required: false
+      argument :post_uuid, String, required: true
+
+      field :post, Types::PostType, null: true
+
+      def resolve(title: 'Untitled', content:, post_uuid:)
+        auth = AUTH_HELPER.new(context[:current_user][:token])
+        token_data = auth.verify_token
+        return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
+        search_means = POST_HELPER.default_search_means
+        current_user = USERS_HELPER.fetch_with_relationship_by({"#{search_means}": token_data[:verified_user][:uuid]},
+                                                               :posts)
+        post = current_user.posts.map{ |post| post if post[:uuid] === post_uuid }
+        return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) if post.blank?
+        post = post.first
+        title = "Untitled" if title.blank?
+        POST_HELPER.update(post, {title: title, content: content})
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/posts/update_post.rb
+++ b/app/graphql/mutations/posts/update_post.rb
@@ -20,7 +20,7 @@ module Mutations
         search_means = POST_HELPER.default_search_means
         current_user = USERS_HELPER.fetch_with_relationship_by({"#{search_means}": token_data[:verified_user][:uuid]},
                                                                :posts)
-        post = current_user.posts.map{ |post| post if post[:uuid] === post_uuid }
+        post = USERS_HELPER.extract_post(current_user, post_uuid)
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) if post.blank?
         post = post.first
         title = "Untitled" if title.blank?

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,5 +5,6 @@ module Types
     field :create_topic, mutation: Mutations::Topics::CreateTopic
     field :update_topic, mutation: Mutations::Topics::UpdateTopic
     field :create_post, mutation: Mutations::Posts::CreatePost
+    field :update_post, mutation: Mutations::Posts::UpdatePost
   end
 end

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -32,8 +32,7 @@ module AuthHelper
     def verify_token
       return { verified?: false, verified_user: nil } unless has_token?
       @decoded = Jwt.decode(@token)
-      return { verified?: true, verified_user: @decoded } if @decoded[:uuid].present? and @decoded[:exp].present?
-      { verified?: false, verified_user: nil }
+      { verified?: true, verified_user: @decoded } if @decoded[:uuid].present? and @decoded[:exp].present?
     end
 
     def isAuthorized?(resource_owner_uuid)

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -3,16 +3,32 @@ module PostHelper
     def self.create(title, content, topic_id)
       post = Post.new(title: title, content: content, topic_id: topic_id)
       if post.save
-       {
-         "post": {
-           "uuid": post[:uuid],
-           "title": post[:title],
-           "content": post[:content]
-         }
-       }
+       build_post_response(post)
       else
         ExceptionHandlerHelper::GQLCustomError.new(post.errors.full_messages)
       end
+    end
+
+    def self.update(model, new_record)
+      if model.update(new_record)
+        build_post_response(model)
+      else
+        ExceptionHandlerHelper::GQLCustomError.new(model.errors.full_messages)
+      end
+    end
+
+    def self.default_search_means(means="uuid")
+      means
+    end
+
+    def self.build_post_response(post_record)
+      {
+        "post": {
+          "uuid": post_record[:uuid],
+          "title": post_record[:title],
+          "content": post_record[:content]
+        }
+      }
     end
   end
 end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -17,7 +17,7 @@ module TopicsHelper
       end
     end
 
-    def self.fetch_with_relationship_by(type, relationship)
+    def self.fetch_with_relationship_by(type, *relationship)
       Topic.includes(relationship).find_by(type)
     end
 
@@ -27,7 +27,7 @@ module TopicsHelper
 
     private
 
-    def self.build_topic_response(topic_record)
+    def build_topic_response(topic_record)
       {
         "topic": {
           "uuid": topic_record[:uuid],

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -25,9 +25,7 @@ module TopicsHelper
       means
     end
 
-    private
-
-    def build_topic_response(topic_record)
+    def self.build_topic_response(topic_record)
       {
         "topic": {
           "uuid": topic_record[:uuid],

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -32,7 +32,9 @@ module UsersHelper
       means
     end
 
-    private
+    def self.extract_post(user_obj, post_uuid)
+      user_obj.posts.map{ |post| post if post[:uuid] === post_uuid }
+    end
 
     def self.build_user_response(user_record, token)
       {

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -24,6 +24,10 @@ module UsersHelper
       User.select(:id).find_by(type)
     end
 
+    def self.fetch_with_relationship_by(type, *relationship)
+      User.includes(relationship).find_by(type)
+    end
+
     def self.default_user_search_means(means = "uuid")
       means
     end

--- a/spec/graphql/mutations/posts/update_post_spec.rb
+++ b/spec/graphql/mutations/posts/update_post_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+module Mutations
+  module Posts
+    RSpec.describe UpdatePost, type: :request  do
+      token = nil
+      topic_uuid = nil
+      post_uuid = nil
+      before(:all) do
+        create(:user)
+        post '/graphql', params: { query: login_mutation(dummy_login_credentials) }
+        json = JSON.parse(response.body)
+        token = json['data']['userLogin']['token']
+      end
+
+      after(:all) do
+        User.destroy_all
+      end
+
+      before(:each) do
+        post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('successful topic')) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        topic_uuid = json['data']['createTopic']['topic']['uuid']
+
+        post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid, "")) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        post_uuid = json['data']['createPost']['post']['uuid']
+      end
+
+      after(:each) do
+        Topic.destroy_all
+      end
+
+      it 'should not successfully update a post without token' do
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid)) }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Auth.token_verification_error )
+      end
+
+      it 'should not successfully update post with expired token' do
+        expired_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxSM'
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid)) },
+             headers: { Authorization: fake_token(expired_token) }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Auth.expired_token )
+      end
+
+      it 'should not successfully update post with invalid token' do
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid)) },
+             headers: { Authorization: fake_token }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Auth.invalid_token )
+      end
+
+      it 'should successfully update a post for a topic' do
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid)) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        post = json['data']['updatePost']['post']
+        expect(post).to include(
+                          "uuid" => be_present,
+                          "title" => dummy_post_update_credentials[:title],
+                          "content" => dummy_post_update_credentials[:content]
+                        )
+      end
+
+      it 'should successfully update post with the right title in every situation' do
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid, "")) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        post = json['data']['updatePost']['post']
+        expect(post).to include(
+                          "uuid" => be_present,
+                          "title" => "Untitled",
+                          "content" => dummy_post_update_credentials[:content]
+                        )
+      end
+
+      it 'should return User unauthorized error if a user tries to update post other than theirs' do
+        user_obj = { name: 'alt_user', screen_name: 'alt_user_p', email: 'alt_user@test.com',
+                     password: '1234567890', password_confirmation: '1234567890' }
+        create(:user, user_obj)
+        post '/graphql', params: { query: login_mutation(dummy_login_credentials(user_obj[:email], user_obj[:password])) }
+        json = JSON.parse(response.body)
+        local_token = json['data']['userLogin']['token']
+
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid, "", nil)) },
+             headers: { Authorization: local_token }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+
+        expect(error).to include( "message" => MessagesHelper::Auth.user_unauthorized )
+      end
+    end
+  end
+end

--- a/spec/helpers/general_spec_helpers.rb
+++ b/spec/helpers/general_spec_helpers.rb
@@ -95,6 +95,25 @@ module Helpers
       GQL
     end
 
+    def update_post_mutation(post)
+      <<~GQL
+        mutation {
+          updatePost(input: {
+            title: "#{post[:title]}"
+            content: "#{post[:content]}"
+            postUuid: "#{post[:post_uuid]}"
+          })
+          {
+            post {
+              uuid
+              title
+              content
+            }
+          }
+        }
+      GQL
+    end
+
     def dummy_login_credentials(email='test@test.com', password= '1234567890')
       {
         email: email,
@@ -122,6 +141,14 @@ module Helpers
        title: title,
        content: content,
        topic_uuid: topic_uuid
+      }
+    end
+
+    def dummy_post_update_credentials(post_uuid=nil, title='update post', content='update my test content')
+      {
+        title: title,
+        content: content,
+        post_uuid: post_uuid
       }
     end
 


### PR DESCRIPTION
#### What does this PR do
This PR adds functionality to update a `Post`

#### Description of Task to be completed
- Add `updatePost` mutation
- Secure `updatePost` mutation for use by only authorised users
- Secure `post` such that only `post` owner can update it

#### How should this be manually tested
- Checkout into this branch and run bundle install and yarn install
- Issue a `POST` request to `localhost:3000/graphql`
- Supply `postUuid`, `title` and `content` attributes to `updatePost` mutation

#### What are the relevant pivotal tracker stories?
[#170309004](https://www.pivotaltracker.com/story/show/170309004)

#### Screenshots
- NIL

