### PR TITLE
#170054562 Add delete_topic mutation

### DIFF
--- a/app/graphql/mutations/topics/delete_topic.rb
+++ b/app/graphql/mutations/topics/delete_topic.rb
@@ -1,0 +1,25 @@
+module Mutations
+  module Topics
+    class DeleteTopic < Mutations::BaseMutation
+      AUTH_HELPER = AuthHelper::Auth
+      AUTH_MSG_HELPER = MessagesHelper::Auth
+      EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
+      TOPIC_HELPER = TopicsHelper::Topics
+      USER_HELPER = UsersHelper::Users
+
+      argument :topic_uuid, String, required: true
+
+      field :topic, Types::TopicType, null: true
+
+      def resolve(topic_uuid:)
+        auth = AUTH_HELPER.new(context[:current_user][:token])
+        token_data = auth.verify_token
+        return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
+        search_means = TOPIC_HELPER.default_topic_search_means
+        topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid}, :user)
+        return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) unless auth.isAuthorized?(topic.user[:uuid])
+        TOPIC_HELPER.destroy(topic)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -4,6 +4,7 @@ module Types
     field :user_login, mutation: Mutations::Users::UserLogin
     field :create_topic, mutation: Mutations::Topics::CreateTopic
     field :update_topic, mutation: Mutations::Topics::UpdateTopic
+    field :delete_topic, mutation: Mutations::Topics::DeleteTopic
     field :create_post, mutation: Mutations::Posts::CreatePost
     field :update_post, mutation: Mutations::Posts::UpdatePost
   end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -17,6 +17,11 @@ module TopicsHelper
       end
     end
 
+    def self.destroy(topic_record)
+      destroyed = topic_record.destroy
+      build_topic_response(destroyed)
+    end
+
     def self.fetch_with_relationship_by(type, *relationship)
       Topic.includes(relationship).find_by(type)
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :topic
   before_save :set_uuid
+  validates_presence_of :title
+  validates :content, exclusion: { in: [nil], message: "cannot be null" }
   validates :uuid, uniqueness: true
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,6 +1,8 @@
 class Topic < ApplicationRecord
   belongs_to :user
   has_many :posts, dependent: :destroy
+  validates :title, presence: true
+  validates :is_public, inclusion: { in: [true, false],  message: "can only be boolean" }
   validates :uuid, uniqueness: true
   before_save :set_uuid
 end

--- a/spec/graphql/mutations/topics/delete_topic_spec.rb
+++ b/spec/graphql/mutations/topics/delete_topic_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
+
 module Mutations
   module Topics
-    RSpec.describe UpdateTopic, type: :request  do
+    RSpec.describe DeleteTopic, type: :request do
       describe '.resolve' do
         token = nil
         topic_uuid = nil
@@ -10,28 +11,31 @@ module Mutations
           post '/graphql', params: { query: login_mutation(dummy_login_credentials) }
           json = JSON.parse(response.body)
           token = json['data']['userLogin']['token']
-        end
 
-        before(:all) do
           post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials) },
                headers: { Authorization: token }
           json = JSON.parse(response.body)
           topic_uuid = json['data']['createTopic']['topic']['uuid']
+
+          post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid, "1st dummy post", nil)) },
+               headers: { Authorization: token }
+          post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid, "2nd dummy post", nil)) },
+               headers: { Authorization: token }
         end
 
         after(:all) do
           User.destroy_all
         end
 
-        it 'should not successfully update a topic without token' do
-          post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('abc', false, topic_uuid)) }
+        it 'should not successfully delete a topic without token' do
+          post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials('first delete test', false, topic_uuid)) }
           json = JSON.parse(response.body)
           error = json['errors'][0]
           expect(error).to include( "message" => MessagesHelper::Auth.token_verification_error )
         end
 
-        it 'should not update a topic with an invalid token' do
-          post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('second update test', false, topic_uuid)) },
+        it 'should not delete a topic with an invalid token' do
+          post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials('second delete test', false, topic_uuid)) },
                headers: { Authorization: fake_token }
           json = JSON.parse(response.body)
           errors = json["errors"]
@@ -40,9 +44,9 @@ module Mutations
                             )
         end
 
-        it 'should not update a topic with an expired token' do
+        it 'should not delete a topic with an expired token' do
           expired_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxJS'
-          post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('third update test', false, topic_uuid)) },
+          post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials('third update test', false, topic_uuid)) },
                headers: { Authorization: fake_token(expired_token) }
           json = JSON.parse(response.body)
           errors = json["errors"]
@@ -51,7 +55,7 @@ module Mutations
                             )
         end
 
-        it 'should return User unauthorized error if a user tries to update topic(s) belonging to other users' do
+        it 'should return User unauthorized error if a user tries to delete topic(s) belonging to other users' do
           user_obj = { name: 'alt_user', screen_name: 'alt_user_p', email: 'alt_user@test.com',
                        password: '1234567890', password_confirmation: '1234567890' }
           create(:user, user_obj)
@@ -59,7 +63,7 @@ module Mutations
           json = JSON.parse(response.body)
           local_token = json['data']['userLogin']['token']
 
-          post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials("Fourth update test", false, topic_uuid)) },
+          post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials("Fourth update test", false, topic_uuid)) },
                headers: { Authorization: local_token }
           json = JSON.parse(response.body)
           error = json['errors'][0]
@@ -67,25 +71,14 @@ module Mutations
           expect(error).to include( "message" => MessagesHelper::Auth.user_unauthorized )
         end
 
-        it 'should successfully update a topic without supplied credentials' do
-          post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('Fifth update test', false, topic_uuid)) },
+        it 'should successfully delete a topic with right credentials supplied' do
+          post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials('', false, topic_uuid)) },
                headers: { Authorization: token }
           json = JSON.parse(response.body)
-          topic = json['data']['updateTopic']['topic']
+          topic = json['data']['deleteTopic']['topic']
           expect(topic).to include(
                              "uuid" => be_present,
-                             "title" => "Fifth update test"
-                           )
-        end
-
-        it 'should successfully update a topic with untitled if an empty title is supplied' do
-          post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('', false, topic_uuid)) },
-               headers: { Authorization: token }
-          json = JSON.parse(response.body)
-          topic = json['data']['updateTopic']['topic']
-          expect(topic).to include(
-                             "uuid" => be_present,
-                             "title" => "Untitled"
+                             "title" => dummy_topic_credentials[:title]
                            )
         end
       end

--- a/spec/helpers/general_spec_helpers.rb
+++ b/spec/helpers/general_spec_helpers.rb
@@ -42,7 +42,21 @@ module Helpers
     end
 
     def topic_mutation(type, topic)
-      if topic[:topic_uuid].present?
+      if type == "deleteTopic"
+        <<~GQL
+        mutation {
+          #{type}(input: {
+            topicUuid: "#{topic[:topic_uuid]}"
+          })
+          {
+            topic {
+              uuid
+              title
+            }
+          }
+        }
+        GQL
+      elsif type == "updateTopic"
         <<~GQL
         mutation {
           #{type}(input: {

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Post, type: :model do
     end
 
     it 'should create Post with default values if no values are supplied' do
-      post = Post.create!(topic: topic)
+      post = Post.create(topic: topic)
       expect(post[:title]).to eq('Untitled')
       expect(post[:content]).to eq('')
       expect(post[:uuid]).to be_present
@@ -27,7 +27,7 @@ RSpec.describe Post, type: :model do
 
     it 'should create Post with supplied values' do
       post_obj = dummy_post_credentials(nil)
-      post = Post.create!(topic:topic, title: post_obj[:title], content: post_obj[:content] )
+      post = Post.create(topic: topic, title: post_obj[:title], content: post_obj[:content] )
       expect(post[:title]).to eq(post_obj[:title])
       expect(post[:content]).to eq(post_obj[:content])
       expect(post[:uuid]).to be_present

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -17,17 +17,22 @@ RSpec.describe Topic, type: :model do
     end
 
     it 'should create topic with default values if no values are supplied' do
-      topic = Topic.create!(user: user)
+      topic = Topic.create(user: user)
       expect(topic[:title]).to eq('Untitled')
       expect(topic[:is_public]).to eq(false)
       expect(topic[:uuid]).to be_present
     end
 
     it 'should create topic with supplied values' do
-      topic = Topic.create!(user: user, title: 'my test', is_public: true)
+      topic = Topic.create(user: user, title: 'my test', is_public: true)
       expect(topic[:title]).to eq('my test')
       expect(topic[:is_public]).to eq(true)
       expect(topic[:uuid]).to be_present
+    end
+
+    it 'should fail if wrong data type is supplied' do
+      topic = Topic.create(user: user, title: 'my test', is_public: "")
+      expect(topic.errors.full_messages).to eq(["Is public can only be boolean"])
     end
 
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe User, type: :model do
     after(:each) do
       User.destroy_all
     end
+
+    it 'should not create user with missing credentials' do
+      user_object = {
+        name: 'tested',
+        password: '1234567890',
+        password_confirmation: '1234567890'
+      }
+      user = User.create user_object
+
+      expect(user.errors.full_messages).to eq(["Email can't be blank", "Screen name can't be blank"])
+    end
+
     it 'should create user with supplied credential' do
       user_object = {
         screen_name: 'tester_p',
@@ -14,7 +26,7 @@ RSpec.describe User, type: :model do
         password: '1234567890',
         password_confirmation: '1234567890'
       }
-      user = User.create! user_object
+      user = User.create user_object
 
       expect(user[:screen_name]).to eq(user_object[:screen_name])
       expect(user[:name]).to eq(user_object[:name])
@@ -31,7 +43,7 @@ RSpec.describe User, type: :model do
         password: '1234567890',
         password_confirmation: '1234567890'
       }
-      user = User.create! user_object
+      user = User.create user_object
 
       found = User.find_by(uuid: user[:uuid])
 


### PR DESCRIPTION
#### What does this PR do
This PR adds functionality to delete a `Topic`

#### Description of Task to be completed
- Add `deleteTopic` mutation
- Secure `deleteTopic` mutation for use by only authorised users
- Secure `topic` such that only `topic` owner can delete it
- Make sure all posts attached to topic are deleted to avoid orphaned data

#### How should this be manually tested
- Checkout into this branch and run bundle install and yarn install
- Issue a `POST` request to `localhost:3000/graphql`
- Supply `topicUuid` attributes to `deleteTopic` mutation

#### What are the relevant pivotal tracker stories?
[#170054562](https://www.pivotaltracker.com/story/show/170054562)

#### Screenshots
- NIL

