### PR TITLE
Ft delete post 170391059

### DIFF
--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -5,6 +5,8 @@ module Mutations
       TOPIC_HELPER = TopicsHelper::Topics
       EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
       AUTH_MSG_HELPER = MessagesHelper::Auth
+      DEFAULT_POST_TITLE = "Untitled"
+      DEFAULT_CONTENT = ""
 
       argument :title, String, required: false
       argument :content, String, required: false
@@ -12,7 +14,7 @@ module Mutations
 
       field :post, Types::PostType, null: true
 
-      def resolve(title: "Untitled", content: "", topic_uuid:)
+      def resolve(title: DEFAULT_POST_TITLE, content: DEFAULT_CONTENT, topic_uuid:)
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
@@ -20,7 +22,7 @@ module Mutations
         topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
         topic_owner = topic.user
         return EXCEPTION_HANDLER.new(MessagesHelper::Auth.user_unauthorized) unless auth.isAuthorized?(topic_owner[:uuid])
-        title = "Untitled" if title.blank?
+        title = DEFAULT_POST_TITLE if title.blank?
         PostHelper::Posts.create(title, content, topic[:id])
       end
     end

--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -5,6 +5,7 @@ module Mutations
       TOPIC_HELPER = TopicsHelper::Topics
       EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
       AUTH_MSG_HELPER = MessagesHelper::Auth
+      POST_HELPER = PostHelper::Posts
       DEFAULT_POST_TITLE = "Untitled"
       DEFAULT_CONTENT = ""
 
@@ -22,8 +23,8 @@ module Mutations
         topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
         topic_owner = topic.user
         return EXCEPTION_HANDLER.new(MessagesHelper::Auth.user_unauthorized) unless auth.isAuthorized?(topic_owner[:uuid])
-        title = DEFAULT_POST_TITLE if title.blank?
-        PostHelper::Posts.create(title, content, topic[:id])
+        title = POST_HELPER.parse_title(title, DEFAULT_POST_TITLE)
+        POST_HELPER.create(title, content, topic[:id])
       end
     end
   end

--- a/app/graphql/mutations/posts/delete_post.rb
+++ b/app/graphql/mutations/posts/delete_post.rb
@@ -1,20 +1,17 @@
 module Mutations
   module Posts
-    class UpdatePost < Mutations::BaseMutation
+    class DeletePost < Mutations::BaseMutation
       AUTH_HELPER = AuthHelper::Auth
       AUTH_MSG_HELPER = MessagesHelper::Auth
       EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
       POST_HELPER = PostHelper::Posts
       USERS_HELPER = UsersHelper::Users
-      DEFAULT_POST_TITLE = "Untitled"
 
-      argument :content, String, required: false
-      argument :title, String, required: false
       argument :post_uuid, String, required: true
 
       field :post, Types::PostType, null: true
 
-      def resolve(title: DEFAULT_POST_TITLE, content:, post_uuid:)
+      def resolve(post_uuid:)
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
@@ -24,8 +21,7 @@ module Mutations
         extracted_post = USERS_HELPER.extract_post(current_user, post_uuid)
         post = extracted_post[:post]
         return EXCEPTION_HANDLER.new(extracted_post[:error_message]) if post.blank?
-        title = DEFAULT_POST_TITLE if title.blank?
-        POST_HELPER.update(post, {title: title, content: content})
+        POST_HELPER.destroy(post)
       end
     end
   end

--- a/app/graphql/mutations/posts/update_post.rb
+++ b/app/graphql/mutations/posts/update_post.rb
@@ -24,7 +24,7 @@ module Mutations
         extracted_post = USERS_HELPER.extract_post(current_user, post_uuid)
         post = extracted_post[:post]
         return EXCEPTION_HANDLER.new(extracted_post[:error_message]) if post.blank?
-        title = DEFAULT_POST_TITLE if title.blank?
+        title = POST_HELPER.parse_title(title, DEFAULT_POST_TITLE)
         POST_HELPER.update(post, {title: title, content: content})
       end
     end

--- a/app/graphql/mutations/topics/create_topic.rb
+++ b/app/graphql/mutations/topics/create_topic.rb
@@ -18,7 +18,7 @@ module Mutations
         if token_data[:verified?]
           search_means = USER_HELPER.default_user_search_means
           current_user_id = USER_HELPER.fetch_by("#{search_means}": token_data[:verified_user][:uuid])[:id]
-          title = DEFAULT_TOPIC_TITLE if title.blank?
+          title = TOPIC_HELPER.parse_title(title, DEFAULT_TOPIC_TITLE)
           TOPIC_HELPER.create(title, is_public, current_user_id)
         else
           EXCEPTION_HANDLER.new(MessagesHelper::Auth.token_verification_error)

--- a/app/graphql/mutations/topics/create_topic.rb
+++ b/app/graphql/mutations/topics/create_topic.rb
@@ -5,19 +5,20 @@ module Mutations
       AUTH_HELPER = AuthHelper::Auth
       USER_HELPER = UsersHelper::Users
       EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
+      DEFAULT_TOPIC_TITLE = "Untitled"
 
       argument :title, String, required: false
       argument :is_public, Boolean, required: false
 
       field :topic, Types::TopicType, null: true
 
-      def resolve(title: 'Untitled', is_public: false)
+      def resolve(title: DEFAULT_TOPIC_TITLE, is_public: false)
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         if token_data[:verified?]
           search_means = USER_HELPER.default_user_search_means
           current_user_id = USER_HELPER.fetch_by("#{search_means}": token_data[:verified_user][:uuid])[:id]
-          title = "Untitled" if title.blank?
+          title = DEFAULT_TOPIC_TITLE if title.blank?
           TOPIC_HELPER.create(title, is_public, current_user_id)
         else
           EXCEPTION_HANDLER.new(MessagesHelper::Auth.token_verification_error)

--- a/app/graphql/mutations/topics/delete_topic.rb
+++ b/app/graphql/mutations/topics/delete_topic.rb
@@ -6,6 +6,7 @@ module Mutations
       EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
       TOPIC_HELPER = TopicsHelper::Topics
       USER_HELPER = UsersHelper::Users
+      RESOURCE_HELPER = MessagesHelper::Resource
 
       argument :topic_uuid, String, required: true
 
@@ -17,6 +18,7 @@ module Mutations
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
         search_means = TOPIC_HELPER.default_topic_search_means
         topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid}, :user)
+        return EXCEPTION_HANDLER.new(RESOURCE_HELPER.not_found(TOPIC_HELPER.resource_name)) if topic.blank?
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) unless auth.isAuthorized?(topic.user[:uuid])
         TOPIC_HELPER.destroy(topic)
       end

--- a/app/graphql/mutations/topics/update_topic.rb
+++ b/app/graphql/mutations/topics/update_topic.rb
@@ -22,7 +22,7 @@ module Mutations
         topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
         return EXCEPTION_HANDLER.new(RESOURCE_HELPER.not_found(TOPIC_HELPER.resource_name)) if topic.blank?
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) unless auth.isAuthorized?(topic.user[:uuid])
-        title = DEFAULT_TOPIC_TITLE if title.blank?
+        title = TOPIC_HELPER.parse_title(title, DEFAULT_TOPIC_TITLE)
         TOPIC_HELPER.update(topic, { title: title, is_public: is_public })
       end
     end

--- a/app/graphql/mutations/topics/update_topic.rb
+++ b/app/graphql/mutations/topics/update_topic.rb
@@ -5,6 +5,8 @@ module Mutations
       TOPIC_HELPER = TopicsHelper::Topics
       EXCEPTION_HANDLER = ExceptionHandlerHelper::GQLCustomError
       AUTH_MSG_HELPER = MessagesHelper::Auth
+      RESOURCE_HELPER = MessagesHelper::Resource
+      DEFAULT_TOPIC_TITLE = "Untitled"
 
       argument :title, String, required: false
       argument :is_public, Boolean, required: false
@@ -12,14 +14,15 @@ module Mutations
 
       field :topic, Types::TopicType, null: true
 
-      def resolve(title: 'Untitled', is_public:, topic_uuid:)
+      def resolve(title: DEFAULT_TOPIC_TITLE, is_public:, topic_uuid:)
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
         search_means = TOPIC_HELPER.default_topic_search_means
         topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
+        return EXCEPTION_HANDLER.new(RESOURCE_HELPER.not_found(TOPIC_HELPER.resource_name)) if topic.blank?
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) unless auth.isAuthorized?(topic.user[:uuid])
-        title = 'Untitled' if title.blank?
+        title = DEFAULT_TOPIC_TITLE if title.blank?
         TOPIC_HELPER.update(topic, { title: title, is_public: is_public })
       end
     end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -7,5 +7,6 @@ module Types
     field :delete_topic, mutation: Mutations::Topics::DeleteTopic
     field :create_post, mutation: Mutations::Posts::CreatePost
     field :update_post, mutation: Mutations::Posts::UpdatePost
+    field :delete_post, mutation: Mutations::Posts::DeletePost
   end
 end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -22,4 +22,11 @@ module MessagesHelper
       "User is unauthorized to perform this action"
     end
   end
+
+  class Resource
+    def self.not_found(resource_type)
+      "#{resource_type} not found"
+    end
+  end
+
 end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -17,6 +17,11 @@ module PostHelper
       end
     end
 
+    def self.destroy(post_record)
+      destroyed = post_record.destroy
+      build_post_response(destroyed)
+    end
+
     def self.default_search_means(means="uuid")
       means
     end
@@ -29,6 +34,10 @@ module PostHelper
           "content": post_record[:content]
         }
       }
+    end
+
+    def self.resource_name
+      "Post"
     end
   end
 end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -22,6 +22,11 @@ module PostHelper
       build_post_response(destroyed)
     end
 
+    def self.parse_title(incoming_title, default_title)
+      return default_title if incoming_title.blank?
+      incoming_title
+    end
+
     def self.default_search_means(means="uuid")
       means
     end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -37,7 +37,7 @@ module PostHelper
     end
 
     def self.resource_name
-      "Post"
+      self.name.split("::").last.singularize
     end
   end
 end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -38,5 +38,9 @@ module TopicsHelper
         }
       }
     end
+
+    def self.resource_name
+      "Topic"
+    end
   end
 end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -26,6 +26,11 @@ module TopicsHelper
       Topic.includes(relationship).find_by(type)
     end
 
+    def self.parse_title(incoming_title, default_title)
+      return default_title if incoming_title.blank?
+      incoming_title
+    end
+
     def self.default_topic_search_means(means = "uuid")
       means
     end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -40,7 +40,7 @@ module TopicsHelper
     end
 
     def self.resource_name
-      "Topic"
+      self.name.split("::").last.singularize
     end
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,9 @@
 module UsersHelper
   class Users
+    AUTH_MSG_HELPER = MessagesHelper::Auth
+    RESOURCE_MSG_HELPER = MessagesHelper::Resource
+    POST_HELPER = PostHelper::Posts
+
     def self.create(user_obj)
       user = User.new(email: user_obj[:email], password: user_obj[:password],
                       password_confirmation: user_obj[:password_confirmation],
@@ -33,7 +37,18 @@ module UsersHelper
     end
 
     def self.extract_post(user_obj, post_uuid)
-      user_obj.posts.map{ |post| post if post[:uuid] === post_uuid }
+      post = user_obj.posts.map{ |post| post if post[:uuid] === post_uuid }.first
+      return build_extract_post_response(post) if post.present?
+      verify_post_exists = Post.find_by("#{default_user_search_means}": post_uuid)
+      return build_extract_post_response(nil, AUTH_MSG_HELPER.user_unauthorized) if post.blank? && verify_post_exists.present?
+      return build_extract_post_response(nil, RESOURCE_MSG_HELPER.not_found(POST_HELPER.resource_name)) if post.blank? && verify_post_exists.blank?
+    end
+
+    def self.build_extract_post_response(post, error_message = nil)
+      {
+        post: post,
+        error_message: error_message
+      }
     end
 
     def self.build_user_response(user_record, token)
@@ -50,6 +65,10 @@ module UsersHelper
         screen_name: user_record[:screen_name],
         name: user_record[:name]
       }
+    end
+
+    def self.resource_name
+      "User"
     end
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -39,9 +39,13 @@ module UsersHelper
     def self.extract_post(user_obj, post_uuid)
       post = user_obj.posts.select{ |post| post if post[:uuid] === post_uuid }.first
       return build_extract_post_response(post) if post.present?
-      verify_post_exists = Post.find_by("#{default_user_search_means}": post_uuid)
-      return build_extract_post_response(nil, AUTH_MSG_HELPER.user_unauthorized) if post.blank? && verify_post_exists.present?
-      return build_extract_post_response(nil, RESOURCE_MSG_HELPER.not_found(POST_HELPER.resource_name)) if post.blank? && verify_post_exists.blank?
+      verify_post_existence(post_uuid, post)
+    end
+
+    def self.verify_post_existence(post_uuid, post_obj)
+      verification =  Post.find_by("#{default_user_search_means}": post_uuid)
+      return build_extract_post_response(nil, AUTH_MSG_HELPER.user_unauthorized) if post_obj.blank? && verification.present?
+      build_extract_post_response(nil, RESOURCE_MSG_HELPER.not_found(POST_HELPER.resource_name)) if post_obj.blank? && verification.blank?
     end
 
     def self.build_extract_post_response(post, error_message = nil)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -37,7 +37,7 @@ module UsersHelper
     end
 
     def self.extract_post(user_obj, post_uuid)
-      post = user_obj.posts.map{ |post| post if post[:uuid] === post_uuid }.first
+      post = user_obj.posts.select{ |post| post if post[:uuid] === post_uuid }.first
       return build_extract_post_response(post) if post.present?
       verify_post_exists = Post.find_by("#{default_user_search_means}": post_uuid)
       return build_extract_post_response(nil, AUTH_MSG_HELPER.user_unauthorized) if post.blank? && verify_post_exists.present?

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -68,7 +68,7 @@ module UsersHelper
     end
 
     def self.resource_name
-      "User"
+      self.name.split("::").last.singularize
     end
   end
 end

--- a/spec/graphql/mutations/posts/create_post_spec.rb
+++ b/spec/graphql/mutations/posts/create_post_spec.rb
@@ -35,7 +35,6 @@ module Mutations
         end
 
         it 'should not successfully create post with expired token' do
-          expired_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxIO'
           post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid)) },
                headers: { Authorization: fake_token(expired_token) }
           json = JSON.parse(response.body)

--- a/spec/graphql/mutations/posts/delete_post_spec.rb
+++ b/spec/graphql/mutations/posts/delete_post_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+module Mutations
+  module Posts
+    RSpec.describe DeletePost, type: :request do
+      token = nil
+      topic_uuid = nil
+      post_uuids = []
+      before(:all) do
+        create(:user)
+        post '/graphql', params: { query: login_mutation(dummy_login_credentials) }
+        json = JSON.parse(response.body)
+        token = json['data']['userLogin']['token']
+      end
+
+      after(:all) do
+        User.destroy_all
+      end
+
+      before(:each) do
+        post_uuids = []
+        post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('successful topic')) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        topic_uuid = json['data']['createTopic']['topic']['uuid']
+
+        post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid, "")) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        post_uuids << json['data']['createPost']['post']['uuid']
+
+        post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid)) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        post_uuids << json['data']['createPost']['post']['uuid']
+      end
+
+      after(:each) do
+        Topic.destroy_all
+      end
+
+      it 'should not successfully delete a post without token' do
+        post '/graphql', params: { query: delete_post_mutation(post_uuid: post_uuids.first) }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Auth.token_verification_error )
+      end
+
+      it 'should not successfully delete post with expired token' do
+        post '/graphql', params: { query: delete_post_mutation(post_uuid: post_uuids.first) },
+             headers: { Authorization: fake_token(expired_token) }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Auth.expired_token )
+      end
+
+      it 'should not successfully delete post with invalid token' do
+        post '/graphql', params: { query: delete_post_mutation(post_uuid: post_uuids.first) },
+             headers: { Authorization: fake_token }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Auth.invalid_token )
+      end
+
+      it 'should return not found error if non-existing uuid is supplied' do
+        post '/graphql', params: { query: delete_post_mutation(post_uuid: "non-existent") },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Resource.not_found(PostHelper::Posts.resource_name) )
+      end
+
+      it 'should not delete posts belonging to other users' do
+        user_obj = { name: 'alt_user', screen_name: 'alt_user_p', email: 'alt_user@test.com',
+                     password: '1234567890', password_confirmation: '1234567890' }
+        create(:user, user_obj)
+        post '/graphql', params: { query: login_mutation(dummy_login_credentials(user_obj[:email], user_obj[:password])) }
+        json = JSON.parse(response.body)
+        local_token = json['data']['userLogin']['token']
+
+        post '/graphql', params: { query: delete_post_mutation(post_uuid: post_uuids.first) },
+             headers: { Authorization: local_token }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+
+        expect(error).to include( "message" => MessagesHelper::Auth.user_unauthorized )
+      end
+
+      it 'should successfully delete first post' do
+        post '/graphql', params: { query: delete_post_mutation(post_uuid: post_uuids.first) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        post = json['data']['deletePost']['post']
+        expect(post).to include(
+                          "uuid" => be_present,
+                          "title" => "Untitled",
+                          "content" => dummy_post_credentials[:content]
+                        )
+      end
+
+      it 'should successfully delete second post' do
+        post '/graphql', params: { query: delete_post_mutation(post_uuid: post_uuids.second) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        post = json['data']['deletePost']['post']
+        expect(post).to include(
+                          "uuid" => be_present,
+                          "title" => dummy_post_credentials[:title],
+                          "content" => dummy_post_credentials[:content]
+                        )
+      end
+
+    end
+  end
+end

--- a/spec/graphql/mutations/posts/update_post_spec.rb
+++ b/spec/graphql/mutations/posts/update_post_spec.rb
@@ -56,6 +56,14 @@ module Mutations
         expect(error).to include( "message" => MessagesHelper::Auth.invalid_token )
       end
 
+      it 'should return not found error if no-existing uuid is supplied' do
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials("jcbshbca")) },
+             headers: { Authorization: token }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+        expect(error).to include( "message" => MessagesHelper::Resource.not_found(PostHelper::Posts.resource_name) )
+      end
+
       it 'should successfully update a post for a topic' do
         post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid)) },
              headers: { Authorization: token }

--- a/spec/graphql/mutations/posts/update_post_spec.rb
+++ b/spec/graphql/mutations/posts/update_post_spec.rb
@@ -40,7 +40,6 @@ module Mutations
       end
 
       it 'should not successfully update post with expired token' do
-        expired_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxSM'
         post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid)) },
              headers: { Authorization: fake_token(expired_token) }
         json = JSON.parse(response.body)
@@ -56,7 +55,7 @@ module Mutations
         expect(error).to include( "message" => MessagesHelper::Auth.invalid_token )
       end
 
-      it 'should return not found error if no-existing uuid is supplied' do
+      it 'should return not found error if non-existing uuid is supplied' do
         post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials("jcbshbca")) },
              headers: { Authorization: token }
         json = JSON.parse(response.body)
@@ -88,7 +87,7 @@ module Mutations
                         )
       end
 
-      it 'should return User unauthorized error if a user tries to update post other than theirs' do
+      it 'should return update posts belonging to other users' do
         user_obj = { name: 'alt_user', screen_name: 'alt_user_p', email: 'alt_user@test.com',
                      password: '1234567890', password_confirmation: '1234567890' }
         create(:user, user_obj)

--- a/spec/graphql/mutations/topics/create_topic_spec.rb
+++ b/spec/graphql/mutations/topics/create_topic_spec.rb
@@ -64,6 +64,17 @@ module Mutations
                              "title" => "second test"
                            )
         end
+
+        it 'should successfully create a topic with untitled if an empty title is supplied' do
+          post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('', false)) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          topic = json['data']['createTopic']['topic']
+          expect(topic).to include(
+                             "uuid" => be_present,
+                             "title" => "Untitled"
+                           )
+        end
       end
     end
   end

--- a/spec/graphql/mutations/topics/create_topic_spec.rb
+++ b/spec/graphql/mutations/topics/create_topic_spec.rb
@@ -34,7 +34,6 @@ module Mutations
         end
 
         it 'should not create a topic with an expired token' do
-          expired_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxJS'
           post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('second test', true)) },
                headers: { Authorization: fake_token(expired_token) }
           json = JSON.parse(response.body)

--- a/spec/graphql/mutations/topics/delete_topic_spec.rb
+++ b/spec/graphql/mutations/topics/delete_topic_spec.rb
@@ -71,6 +71,14 @@ module Mutations
           expect(error).to include( "message" => MessagesHelper::Auth.user_unauthorized )
         end
 
+        it 'should return not found error if non-existing uuid is supplied' do
+          post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials('', false, '')) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          error = json['errors'][0]
+          expect(error).to include( "message" => MessagesHelper::Resource.not_found(TopicsHelper::Topics.resource_name))
+        end
+
         it 'should successfully delete a topic with right credentials supplied' do
           post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials('', false, topic_uuid)) },
                headers: { Authorization: token }

--- a/spec/graphql/mutations/topics/delete_topic_spec.rb
+++ b/spec/graphql/mutations/topics/delete_topic_spec.rb
@@ -45,7 +45,6 @@ module Mutations
         end
 
         it 'should not delete a topic with an expired token' do
-          expired_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxJS'
           post '/graphql', params: { query: topic_mutation("deleteTopic", dummy_topic_credentials('third update test', false, topic_uuid)) },
                headers: { Authorization: fake_token(expired_token) }
           json = JSON.parse(response.body)

--- a/spec/graphql/mutations/topics/update_topic_spec.rb
+++ b/spec/graphql/mutations/topics/update_topic_spec.rb
@@ -41,7 +41,6 @@ module Mutations
         end
 
         it 'should not update a topic with an expired token' do
-          expired_token = 'eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxJS'
           post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('third update test', false, topic_uuid)) },
                headers: { Authorization: fake_token(expired_token) }
           json = JSON.parse(response.body)

--- a/spec/graphql/mutations/topics/update_topic_spec.rb
+++ b/spec/graphql/mutations/topics/update_topic_spec.rb
@@ -66,6 +66,14 @@ module Mutations
           expect(error).to include( "message" => MessagesHelper::Auth.user_unauthorized )
         end
 
+        it 'should not update non-existing topic' do
+          post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('', false, 'non-existing topic')) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          error = json['errors'][0]
+          expect(error).to include( "message" => MessagesHelper::Resource.not_found(TopicsHelper::Topics.resource_name))
+        end
+
         it 'should successfully update a topic without supplied credentials' do
           post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('Fifth update test', false, topic_uuid)) },
                headers: { Authorization: token }

--- a/spec/graphql/mutations/topics/update_topic_spec.rb
+++ b/spec/graphql/mutations/topics/update_topic_spec.rb
@@ -74,7 +74,7 @@ module Mutations
           expect(error).to include( "message" => MessagesHelper::Resource.not_found(TopicsHelper::Topics.resource_name))
         end
 
-        it 'should successfully update a topic without supplied credentials' do
+        it 'should successfully update a topic with supplied credentials' do
           post '/graphql', params: { query: topic_mutation("updateTopic", dummy_topic_credentials('Fifth update test', false, topic_uuid)) },
                headers: { Authorization: token }
           json = JSON.parse(response.body)

--- a/spec/helpers/general_spec_helpers.rb
+++ b/spec/helpers/general_spec_helpers.rb
@@ -187,8 +187,8 @@ module Helpers
       token
     end
 
-    def expired_token
-      "eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxSM"
+    def expired_token(token = "eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxSM")
+      token
     end
   end
 end

--- a/spec/helpers/general_spec_helpers.rb
+++ b/spec/helpers/general_spec_helpers.rb
@@ -128,6 +128,23 @@ module Helpers
       GQL
     end
 
+    def delete_post_mutation(post_uuid:)
+      <<~GQL
+        mutation {
+          deletePost(input: {
+            postUuid: "#{post_uuid}"
+          })
+          {
+            post {
+              uuid
+              title
+              content
+            }
+          }
+        }
+      GQL
+    end
+
     def dummy_login_credentials(email='test@test.com', password= '1234567890')
       {
         email: email,
@@ -168,6 +185,10 @@ module Helpers
 
     def fake_token(token = 'eyJhbGciOiJIUzI1Nikh.eyJ1dWlkIjggjMzc5OTAyYzdgMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnHD7IqxSJG')
       token
+    end
+
+    def expired_token
+      "eyJhbGciOiJIUzI1NiJ9.eyJ1dWlkIjoiMzc5OTAyYzEtMjczYy00Y2U2LWJkODMtNzQyMTNkMzI4MzkwIiwiZXhwIjoxNTc3MjE4MjQ1fQ.dhrjEf3JNf9Pa9YJXdzpAVcH9jitIsNdNOnCo7IqxSM"
     end
   end
 end


### PR DESCRIPTION
#### What does this PR do
This PR adds functionality to delete a `Post`

#### Description of Task to be completed
- Add `deletePost` mutation
- Secure `deletePost` mutation for use by only authorised users
- Secure `post` such that only `post` owner can delete it

#### How should this be manually tested
- Checkout into this branch and run bundle install and yarn install
- Issue a `POST` request to `localhost:3000/graphql`
- Supply `postUuid` attributes to `deletePost` mutation

#### What are the relevant pivotal tracker stories?
[#170391059](https://www.pivotaltracker.com/story/show/170391059)

#### Screenshots
- NIL

