### PR TITLE
Ft Mark topic private #170052904

### DIFF
--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -19,7 +19,7 @@ module Mutations
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
-        search_means = TOPIC_HELPER.default_topic_search_means
+        search_means = TOPIC_HELPER.default_search_means
         topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
         topic_owner = topic.user
         return EXCEPTION_HANDLER.new(MessagesHelper::Auth.user_unauthorized) unless auth.isAuthorized?(topic_owner[:uuid])

--- a/app/graphql/mutations/topics/create_topic.rb
+++ b/app/graphql/mutations/topics/create_topic.rb
@@ -16,7 +16,7 @@ module Mutations
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         if token_data[:verified?]
-          search_means = USER_HELPER.default_user_search_means
+          search_means = USER_HELPER.default_search_means
           current_user_id = USER_HELPER.fetch_by("#{search_means}": token_data[:verified_user][:uuid])[:id]
           title = TOPIC_HELPER.parse_title(title, DEFAULT_TOPIC_TITLE)
           TOPIC_HELPER.create(title, is_public, current_user_id)

--- a/app/graphql/mutations/topics/delete_topic.rb
+++ b/app/graphql/mutations/topics/delete_topic.rb
@@ -16,7 +16,7 @@ module Mutations
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
-        search_means = TOPIC_HELPER.default_topic_search_means
+        search_means = TOPIC_HELPER.default_search_means
         topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid}, :user)
         return EXCEPTION_HANDLER.new(RESOURCE_HELPER.not_found(TOPIC_HELPER.resource_name)) if topic.blank?
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) unless auth.isAuthorized?(topic.user[:uuid])

--- a/app/graphql/mutations/topics/update_topic.rb
+++ b/app/graphql/mutations/topics/update_topic.rb
@@ -18,8 +18,8 @@ module Mutations
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
-        search_means = TOPIC_HELPER.default_topic_search_means
-        topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user)
+        search_means = TOPIC_HELPER.default_search_means
+        topic = TOPIC_HELPER.fetch_with_relationship_by({"#{search_means}": topic_uuid} , :user, :posts)
         return EXCEPTION_HANDLER.new(RESOURCE_HELPER.not_found(TOPIC_HELPER.resource_name)) if topic.blank?
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.user_unauthorized) unless auth.isAuthorized?(topic.user[:uuid])
         title = TOPIC_HELPER.parse_title(title, DEFAULT_TOPIC_TITLE)

--- a/app/graphql/mutations/users/create_user.rb
+++ b/app/graphql/mutations/users/create_user.rb
@@ -9,7 +9,6 @@ module Mutations
 
       field :user, Types::UserType, null: true
       field :token, String, null: true
-      # field :errors, [String], null: true
 
       def resolve(email:, password:, password_confirmation:, screen_name:, name:)
         user_obj = { 'email': email, 'password': password,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/app/helpers/base_helper.rb
+++ b/app/helpers/base_helper.rb
@@ -1,0 +1,16 @@
+module BaseHelper
+  class Base
+    def self.parse_title(incoming_title, default_title)
+      return default_title if incoming_title.blank?
+      incoming_title
+    end
+
+    def self.resource_name
+      self.name.split("::").last.singularize
+    end
+
+    def self.default_search_means(means="uuid")
+      means
+    end
+  end
+end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,2 +1,0 @@
-module HomeHelper
-end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,5 +1,5 @@
 module PostHelper
-  class Posts
+  class Posts < BaseHelper::Base
     def self.create(title, content, topic_id)
       post = Post.new(title: title, content: content, topic_id: topic_id)
       if post.save
@@ -22,15 +22,6 @@ module PostHelper
       build_post_response(destroyed)
     end
 
-    def self.parse_title(incoming_title, default_title)
-      return default_title if incoming_title.blank?
-      incoming_title
-    end
-
-    def self.default_search_means(means="uuid")
-      means
-    end
-
     def self.build_post_response(post_record)
       {
         "post": {
@@ -39,10 +30,6 @@ module PostHelper
           "content": post_record[:content]
         }
       }
-    end
-
-    def self.resource_name
-      self.name.split("::").last.singularize
     end
   end
 end

--- a/app/helpers/topics_helper.rb
+++ b/app/helpers/topics_helper.rb
@@ -1,5 +1,5 @@
 module TopicsHelper
-  class Topics
+  class Topics < BaseHelper::Base
     def self.create(title, is_public, user_id)
       topic = Topic.new(title: title, is_public: is_public, user_id: user_id)
       if topic.save
@@ -10,6 +10,7 @@ module TopicsHelper
     end
 
     def self.update(model, new_record)
+      model.posts.update_all(is_public: new_record[:is_public]) unless new_record[:is_public]
       if model.update(new_record)
         build_topic_response(model)
       else
@@ -26,15 +27,6 @@ module TopicsHelper
       Topic.includes(relationship).find_by(type)
     end
 
-    def self.parse_title(incoming_title, default_title)
-      return default_title if incoming_title.blank?
-      incoming_title
-    end
-
-    def self.default_topic_search_means(means = "uuid")
-      means
-    end
-
     def self.build_topic_response(topic_record)
       {
         "topic": {
@@ -42,10 +34,6 @@ module TopicsHelper
           "title": topic_record[:title]
         }
       }
-    end
-
-    def self.resource_name
-      self.name.split("::").last.singularize
     end
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,5 @@
 module UsersHelper
-  class Users
+  class Users < BaseHelper::Base
     AUTH_MSG_HELPER = MessagesHelper::Auth
     RESOURCE_MSG_HELPER = MessagesHelper::Resource
     POST_HELPER = PostHelper::Posts
@@ -32,10 +32,6 @@ module UsersHelper
       User.includes(relationship).find_by(type)
     end
 
-    def self.default_user_search_means(means = "uuid")
-      means
-    end
-
     def self.extract_post(user_obj, post_uuid)
       post = user_obj.posts.select{ |post| post if post[:uuid] === post_uuid }.first
       return build_extract_post_response(post) if post.present?
@@ -43,7 +39,7 @@ module UsersHelper
     end
 
     def self.verify_post_existence(post_uuid, post_obj)
-      verification =  Post.find_by("#{default_user_search_means}": post_uuid)
+      verification =  Post.find_by("#{default_search_means}": post_uuid)
       return build_extract_post_response(nil, AUTH_MSG_HELPER.user_unauthorized) if post_obj.blank? && verification.present?
       build_extract_post_response(nil, RESOURCE_MSG_HELPER.not_found(POST_HELPER.resource_name)) if post_obj.blank? && verification.blank?
     end
@@ -69,10 +65,6 @@ module UsersHelper
         screen_name: user_record[:screen_name],
         name: user_record[:name]
       }
-    end
-
-    def self.resource_name
-      self.name.split("::").last.singularize
     end
   end
 end

--- a/db/migrate/20200109191445_add_is_public_to_posts.rb
+++ b/db/migrate/20200109191445_add_is_public_to_posts.rb
@@ -1,0 +1,5 @@
+class AddIsPublicToPosts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :is_public, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_16_145052) do
+ActiveRecord::Schema.define(version: 2020_01_09_191445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_12_16_145052) do
     t.uuid "uuid", null: false
     t.string "title", default: "Untitled", null: false
     t.text "content", default: "", null: false
+    t.boolean "is_public", default: false, null: false
     t.index ["topic_id"], name: "index_posts_on_topic_id"
     t.index ["uuid"], name: "index_posts_on_uuid", unique: true
   end

--- a/spec/graphql/mutations/posts/update_post_spec.rb
+++ b/spec/graphql/mutations/posts/update_post_spec.rb
@@ -87,7 +87,7 @@ module Mutations
                         )
       end
 
-      it 'should return update posts belonging to other users' do
+      it 'should not successfully update posts belonging to other users' do
         user_obj = { name: 'alt_user', screen_name: 'alt_user_p', email: 'alt_user@test.com',
                      password: '1234567890', password_confirmation: '1234567890' }
         create(:user, user_obj)

--- a/spec/helpers/general_spec_helpers.rb
+++ b/spec/helpers/general_spec_helpers.rb
@@ -167,11 +167,12 @@ module Helpers
       end
     end
 
-    def dummy_post_credentials(topic_uuid=nil, title='test post', content='my test content')
+    def dummy_post_credentials(topic_uuid=nil, title='test post', content='my test content', is_public=false)
       {
        title: title,
        content: content,
-       topic_uuid: topic_uuid
+       topic_uuid: topic_uuid,
+       is_public: is_public
       }
     end
 


### PR DESCRIPTION
#### What does this PR do
This PR adds functionality mark a `Topic` private

#### Description of Task to be completed
- Modify Post table to carry is_public attribute
- Refactor update_topic mutation to make all associated posts private if parent topic is toggled private
- Refactor helpers to inherit common methods from common base helper
- Refactor topics specs to test effect of topic's public status toggle on child(ren) post(s)
- Remove unused application & home helper files

#### How should this be manually tested
- Checkout into this branch and run bundle install and yarn install
- Issue a `POST` request to `localhost:3000/graphql`
- Supply `title`, `is_public` & `topicUuid` attributes to `updateTopic` mutation

#### What are the relevant pivotal tracker stories?
[#170052904](https://www.pivotaltracker.com/story/show/170052904)

#### Screenshots
- NIL

