### PR TITLE
#170547133 Ft mark post private

### DIFF
--- a/app/graphql/mutations/posts/create_post.rb
+++ b/app/graphql/mutations/posts/create_post.rb
@@ -8,14 +8,16 @@ module Mutations
       POST_HELPER = PostHelper::Posts
       DEFAULT_POST_TITLE = "Untitled"
       DEFAULT_CONTENT = ""
+      DEFAULT_VISIBILITY_STATUS = false
 
+      argument :topic_uuid, String, required: true
       argument :title, String, required: false
       argument :content, String, required: false
-      argument :topic_uuid, String, required: true
+      argument :is_public, Boolean, required: false
 
       field :post, Types::PostType, null: true
 
-      def resolve(title: DEFAULT_POST_TITLE, content: DEFAULT_CONTENT, topic_uuid:)
+      def resolve(title: DEFAULT_POST_TITLE, content: DEFAULT_CONTENT, is_public: DEFAULT_VISIBILITY_STATUS, topic_uuid:)
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
@@ -24,7 +26,8 @@ module Mutations
         topic_owner = topic.user
         return EXCEPTION_HANDLER.new(MessagesHelper::Auth.user_unauthorized) unless auth.isAuthorized?(topic_owner[:uuid])
         title = POST_HELPER.parse_title(title, DEFAULT_POST_TITLE)
-        POST_HELPER.create(title, content, topic[:id])
+        is_public = POST_HELPER.infer_visibility_status(topic, is_public)
+        POST_HELPER.create(title, content, is_public, topic[:id])
       end
     end
   end

--- a/app/graphql/mutations/posts/update_post.rb
+++ b/app/graphql/mutations/posts/update_post.rb
@@ -7,6 +7,7 @@ module Mutations
       POST_HELPER = PostHelper::Posts
       USERS_HELPER = UsersHelper::Users
       DEFAULT_POST_TITLE = "Untitled"
+      DEFAULT_VISIBILITY_STATUS = false
 
       argument :post_uuid, String, required: true
       argument :content, String, required: false
@@ -15,7 +16,7 @@ module Mutations
 
       field :post, Types::PostType, null: true
 
-      def resolve(title: DEFAULT_POST_TITLE, content:, is_public: false, post_uuid:)
+      def resolve(title: DEFAULT_POST_TITLE, content:, is_public: DEFAULT_VISIBILITY_STATUS, post_uuid:)
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]

--- a/app/graphql/mutations/posts/update_post.rb
+++ b/app/graphql/mutations/posts/update_post.rb
@@ -8,13 +8,14 @@ module Mutations
       USERS_HELPER = UsersHelper::Users
       DEFAULT_POST_TITLE = "Untitled"
 
+      argument :post_uuid, String, required: true
       argument :content, String, required: false
       argument :title, String, required: false
-      argument :post_uuid, String, required: true
+      argument :is_public, Boolean, required: false
 
       field :post, Types::PostType, null: true
 
-      def resolve(title: DEFAULT_POST_TITLE, content:, post_uuid:)
+      def resolve(title: DEFAULT_POST_TITLE, content:, is_public: false, post_uuid:)
         auth = AUTH_HELPER.new(context[:current_user][:token])
         token_data = auth.verify_token
         return EXCEPTION_HANDLER.new(AUTH_MSG_HELPER.token_verification_error) unless token_data[:verified?]
@@ -25,7 +26,8 @@ module Mutations
         post = extracted_post[:post]
         return EXCEPTION_HANDLER.new(extracted_post[:error_message]) if post.blank?
         title = POST_HELPER.parse_title(title, DEFAULT_POST_TITLE)
-        POST_HELPER.update(post, {title: title, content: content})
+        is_public = POST_HELPER.infer_visibility_status(post.topic, is_public)
+        POST_HELPER.update(post, {title: title, content: content, is_public: is_public})
       end
     end
   end

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -1,7 +1,7 @@
 module PostHelper
   class Posts < BaseHelper::Base
-    def self.create(title, content, topic_id)
-      post = Post.new(title: title, content: content, topic_id: topic_id)
+    def self.create(title, content, is_public, topic_id)
+      post = Post.new(title: title, content: content, is_public: is_public, topic_id: topic_id)
       if post.save
        build_post_response(post)
       else

--- a/app/helpers/post_helper.rb
+++ b/app/helpers/post_helper.rb
@@ -22,6 +22,11 @@ module PostHelper
       build_post_response(destroyed)
     end
 
+    def self.infer_visibility_status(topic_record, new_visibility_status)
+      return topic_record[:is_public] unless topic_record[:is_public]
+      new_visibility_status
+    end
+
     def self.build_post_response(post_record)
       {
         "post": {

--- a/spec/graphql/mutations/posts/create_post_spec.rb
+++ b/spec/graphql/mutations/posts/create_post_spec.rb
@@ -17,7 +17,7 @@ module Mutations
         end
 
         before(:each) do
-          post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('successful')) },
+          post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('successful', false)) },
                headers: { Authorization: token }
           json = JSON.parse(response.body)
           topic_uuid = json['data']['createTopic']['topic']['uuid']
@@ -84,6 +84,16 @@ module Mutations
                             "title" => "Untitled",
                             "content" => ""
                           )
+        end
+
+        it 'should successfully create post with the visibility status' do
+          post '/graphql', params: { query: create_post_mutation(dummy_post_credentials(topic_uuid, "", nil, true)) },
+               headers: { Authorization: token }
+          json = JSON.parse(response.body)
+          post = json['data']['createPost']['post']
+
+          post_record = Post.find_by("uuid": post["uuid"])
+          expect(post_record[:is_public]).to be(false)
         end
 
         it 'should return User unauthorized error if a user tries to add post to topic other than theirs' do

--- a/spec/graphql/mutations/posts/update_post_spec.rb
+++ b/spec/graphql/mutations/posts/update_post_spec.rb
@@ -17,7 +17,7 @@ module Mutations
       end
 
       before(:each) do
-        post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('successful topic')) },
+        post '/graphql', params: { query: topic_mutation("createTopic", dummy_topic_credentials('successful topic', false)) },
              headers: { Authorization: token }
         json = JSON.parse(response.body)
         topic_uuid = json['data']['createTopic']['topic']['uuid']
@@ -63,6 +63,22 @@ module Mutations
         expect(error).to include( "message" => MessagesHelper::Resource.not_found(PostHelper::Posts.resource_name) )
       end
 
+      it 'should not successfully update posts belonging to other users' do
+        user_obj = { name: 'alt_user', screen_name: 'alt_user_p', email: 'alt_user@test.com',
+                     password: '1234567890', password_confirmation: '1234567890' }
+        create(:user, user_obj)
+        post '/graphql', params: { query: login_mutation(dummy_login_credentials(user_obj[:email], user_obj[:password])) }
+        json = JSON.parse(response.body)
+        local_token = json['data']['userLogin']['token']
+
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid, "", nil)) },
+             headers: { Authorization: local_token }
+        json = JSON.parse(response.body)
+        error = json['errors'][0]
+
+        expect(error).to include( "message" => MessagesHelper::Auth.user_unauthorized )
+      end
+
       it 'should successfully update a post for a topic' do
         post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid)) },
              headers: { Authorization: token }
@@ -87,20 +103,23 @@ module Mutations
                         )
       end
 
-      it 'should not successfully update posts belonging to other users' do
-        user_obj = { name: 'alt_user', screen_name: 'alt_user_p', email: 'alt_user@test.com',
-                     password: '1234567890', password_confirmation: '1234567890' }
-        create(:user, user_obj)
-        post '/graphql', params: { query: login_mutation(dummy_login_credentials(user_obj[:email], user_obj[:password])) }
+      it 'should successfully update post with the right visibility status [false]' do
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid, "", nil, true)) },
+             headers: { Authorization: token }
         json = JSON.parse(response.body)
-        local_token = json['data']['userLogin']['token']
+        post = json['data']['updatePost']['post']
+        post_record = Post.find_by("uuid": post["uuid"])
+        expect(post_record[:is_public]).to be(false)
+      end
 
-        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid, "", nil)) },
-             headers: { Authorization: local_token }
+      it 'should successfully update post with the right visibility status [true]' do
+        Topic.find_by("uuid": topic_uuid).update({is_public: true})
+        post '/graphql', params: { query: update_post_mutation(dummy_post_update_credentials(post_uuid, "", nil, true)) },
+             headers: { Authorization: token }
         json = JSON.parse(response.body)
-        error = json['errors'][0]
-
-        expect(error).to include( "message" => MessagesHelper::Auth.user_unauthorized )
+        post = json['data']['updatePost']['post']
+        post_record = Post.find_by("uuid": post["uuid"])
+        expect(post_record[:is_public]).to be(true)
       end
     end
   end

--- a/spec/helpers/general_spec_helpers.rb
+++ b/spec/helpers/general_spec_helpers.rb
@@ -96,6 +96,7 @@ module Helpers
           createPost(input: {
             title: "#{post[:title]}"
             content: "#{post[:content]}"
+            isPublic: #{post[:is_public]}
             topicUuid: "#{post[:topic_uuid]}"
           })
           {
@@ -115,6 +116,7 @@ module Helpers
           updatePost(input: {
             title: "#{post[:title]}"
             content: "#{post[:content]}"
+            isPublic: #{post[:is_public]}
             postUuid: "#{post[:post_uuid]}"
           })
           {
@@ -171,15 +173,16 @@ module Helpers
       {
        title: title,
        content: content,
-       topic_uuid: topic_uuid,
-       is_public: is_public
+       is_public: is_public,
+       topic_uuid: topic_uuid
       }
     end
 
-    def dummy_post_update_credentials(post_uuid=nil, title='update post', content='update my test content')
+    def dummy_post_update_credentials(post_uuid=nil, title='update post', content='update my test content', is_public=false)
       {
         title: title,
         content: content,
+        is_public: is_public,
         post_uuid: post_uuid
       }
     end


### PR DESCRIPTION
#### What does this PR do
This PR adds functionality to mark a `Post` private

#### Description of Task to be completed
- Refactor `create_post` & `update_post` mutation to infer correct `Post`'s public visibility status based on its parent `Topic`'s visibility status
- Refactor `create_post` & `update_post` specs to test visibility toggle

#### How should this be manually tested
- Checkout into this branch and run bundle install and yarn install
- Issue a `POST` request to `localhost:3000/graphql`
- Supply `title`,  `content`, `is_public` & `postUuid` attributes to `updatePost` mutation or
- Supply `title`,  `content`, `is_public` & `topicUuid` attributes to `createPost` mutation

#### What are the relevant pivotal tracker stories?
[#170547133](https://www.pivotaltracker.com/story/show/170547133)

#### Screenshots
- NIL

